### PR TITLE
Fix SSM and ASM URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ components:
         secrets:
           MY_SECRET: "my-secret-value"
           MY_SECRET_2: "nacl:dGVzdC12YWx1ZS0yCg=="
-          MY_SECRET_3: "ssm:/my/secret/path"
-          MY_SECRET_4: "sm:secret-name"
+          MY_SECRET_3: "ssm:///my/secret/path"
+          MY_SECRET_4: "asm://secret-name"
         variables:
           MY_VARIABLE: "my-variable-value"
-          MY_VARIABLE_2: "ssm:/my/variable/path"
-          MY_VARIABLE_3: "sm:variable-name"
+          MY_VARIABLE_2: "ssm:///my/variable/path"
+          MY_VARIABLE_3: "asm://variable-name"
 ```
 
 ## Secrets and variables
@@ -82,8 +82,8 @@ components:
 The component supports setting repository and environment secrets and variables. 
 Secrets and variables can be set using the following methods:
 - Raw values (unencrypted string) (example: `my-secret-value`)
-- AWS Secrets Manager (SM) (example: `sm:secret-name`)
-- AWS Systems Manager Parameter Store (SSM) (example: `ssm:/my/secret/path`)
+- AWS Secrets Manager (SM) (example: `asm://secret-name`)
+- AWS Systems Manager Parameter Store (SSM) (example: `ssm:///my/secret/path`)
 
 In addition to that secrets supports base64 encoded values [encrypted](https://docs.github.com/en/rest/guides/encrypting-secrets-for-the-rest-api?apiVersion=2022-11-28) 
 with [repository key](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#get-a-repository-public-key).

--- a/README.yaml
+++ b/README.yaml
@@ -30,12 +30,12 @@ usage: |-
           secrets:
             MY_SECRET: "my-secret-value"
             MY_SECRET_2: "nacl:dGVzdC12YWx1ZS0yCg=="
-            MY_SECRET_3: "ssm:/my/secret/path"
-            MY_SECRET_4: "sm:secret-name"
+            MY_SECRET_3: "ssm:///my/secret/path"
+            MY_SECRET_4: "asm://secret-name"
           variables:
             MY_VARIABLE: "my-variable-value"
-            MY_VARIABLE_2: "ssm:/my/variable/path"
-            MY_VARIABLE_3: "sm:variable-name"
+            MY_VARIABLE_2: "ssm:///my/variable/path"
+            MY_VARIABLE_3: "asm://variable-name"
   ```
 
   ## Secrets and variables
@@ -43,8 +43,8 @@ usage: |-
   The component supports setting repository and environment secrets and variables. 
   Secrets and variables can be set using the following methods:
   - Raw values (unencrypted string) (example: `my-secret-value`)
-  - AWS Secrets Manager (SM) (example: `sm:secret-name`)
-  - AWS Systems Manager Parameter Store (SSM) (example: `ssm:/my/secret/path`)
+  - AWS Secrets Manager (SM) (example: `asm://secret-name`)
+  - AWS Systems Manager Parameter Store (SSM) (example: `ssm:///my/secret/path`)
 
   In addition to that secrets supports base64 encoded values [encrypted](https://docs.github.com/en/rest/guides/encrypting-secrets-for-the-rest-api?apiVersion=2022-11-28) 
   with [repository key](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#get-a-repository-public-key).

--- a/src/README.md
+++ b/src/README.md
@@ -24,12 +24,12 @@ components:
         secrets:
           MY_SECRET: "my-secret-value"
           MY_SECRET_2: "nacl:dGVzdC12YWx1ZS0yCg=="
-          MY_SECRET_3: "ssm:/my/secret/path"
-          MY_SECRET_4: "sm:secret-name"
+          MY_SECRET_3: "ssm:///my/secret/path"
+          MY_SECRET_4: "asm://secret-name"
         variables:
           MY_VARIABLE: "my-variable-value"
-          MY_VARIABLE_2: "ssm:/my/variable/path"
-          MY_VARIABLE_3: "sm:variable-name"
+          MY_VARIABLE_2: "ssm:///my/variable/path"
+          MY_VARIABLE_3: "asm://variable-name"
 ```
 
 ## Secrets and variables
@@ -37,8 +37,8 @@ components:
 The component supports setting repository and environment secrets and variables.
 Secrets and variables can be set using the following methods:
 - Raw values (unencrypted string) (example: `my-secret-value`)
-- AWS Secrets Manager (SM) (example: `sm:secret-name`)
-- AWS Systems Manager Parameter Store (SSM) (example: `ssm:/my/secret/path`)
+- AWS Secrets Manager (SM) (example: `asm://secret-name`)
+- AWS Systems Manager Parameter Store (SSM) (example: `ssm:///my/secret/path`)
 
 In addition to that secrets supports base64 encoded values [encrypted](https://docs.github.com/en/rest/guides/encrypting-secrets-for-the-rest-api?apiVersion=2022-11-28)
 with [repository key](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#get-a-repository-public-key).

--- a/src/main.tf
+++ b/src/main.tf
@@ -74,15 +74,15 @@ module "repository" {
 locals {
   secrets = sensitive({
     for k, v in coalesce(var.secrets, {}) : k => (
-      startswith(v, "ssm:") ? data.aws_ssm_parameter.default[v].value :
-      startswith(v, "sm:") ? data.aws_secretsmanager_secret_version.default[v].secret_string : v
+      startswith(v, "ssm://") ? data.aws_ssm_parameter.default[v].value :
+      startswith(v, "asm://") ? data.aws_secretsmanager_secret_version.default[v].secret_string : v
     )
   })
 
   variables = {
     for k, v in try(var.variables, {}) : k => (
-      startswith(v, "ssm:") ? nonsensitive(data.aws_ssm_parameter.default[v].value) :
-      startswith(v, "sm:") ? nonsensitive(data.aws_secretsmanager_secret_version.default[v].secret_string) : v
+      startswith(v, "ssm://") ? nonsensitive(data.aws_ssm_parameter.default[v].value) :
+      startswith(v, "asm://") ? nonsensitive(data.aws_secretsmanager_secret_version.default[v].secret_string) : v
     )
   }
 
@@ -93,14 +93,14 @@ locals {
       prevent_self_review = v.prevent_self_review
       variables = {
         for name, variable in coalesce(v.variables, {}) : name => (
-          startswith(variable, "ssm:") ? nonsensitive(data.aws_ssm_parameter.default[variable].value) :
-          startswith(variable, "sm:") ? nonsensitive(data.aws_secretsmanager_secret_version.default[variable].secret_string) : variable
+          startswith(variable, "ssm://") ? nonsensitive(data.aws_ssm_parameter.default[variable].value) :
+          startswith(variable, "asm://") ? nonsensitive(data.aws_secretsmanager_secret_version.default[variable].secret_string) : variable
         )
       }
       secrets = {
         for name, secret in coalesce(v.secrets, {}) : name => (
-          startswith(secret, "ssm:") ? nonsensitive(data.aws_ssm_parameter.default[secret].value) :
-          startswith(secret, "sm:") ? nonsensitive(data.aws_secretsmanager_secret_version.default[secret].secret_string) : secret
+          startswith(secret, "ssm://") ? nonsensitive(data.aws_ssm_parameter.default[secret].value) :
+          startswith(secret, "asm://") ? nonsensitive(data.aws_secretsmanager_secret_version.default[secret].secret_string) : secret
         )
       }
     }
@@ -109,20 +109,20 @@ locals {
   ssm_parameters = merge(flatten([
     [
       {
-        for k, v in coalesce(var.variables, {}) : v => trimprefix(v, "ssm:") if startswith(v, "ssm:")
+        for k, v in coalesce(var.variables, {}) : v => trimprefix(v, "ssm://") if startswith(v, "ssm://")
       },
       {
-        for k, v in coalesce(var.secrets, {}) : v => trimprefix(v, "ssm:") if startswith(v, "ssm:")
+        for k, v in coalesce(var.secrets, {}) : v => trimprefix(v, "ssm://") if startswith(v, "ssm://")
       },
     ],
     [
       for k, v in coalesce(var.environments, {}) : {
-        for name, variable in coalesce(v.variables, {}) : variable => trimprefix(variable, "ssm:") if startswith(variable, "ssm:")
+        for name, variable in coalesce(v.variables, {}) : variable => trimprefix(variable, "ssm://") if startswith(variable, "ssm://")
       }
     ],
     [
       for k, v in coalesce(var.environments, {}) : {
-        for name, secret in coalesce(v.secrets, {}) : secret => trimprefix(secret, "ssm:") if startswith(secret, "ssm:")
+        for name, secret in coalesce(v.secrets, {}) : secret => trimprefix(secret, "ssm://") if startswith(secret, "ssm://")
       }
     ]
   ])...)
@@ -131,20 +131,20 @@ locals {
   sm_parameters = merge(flatten([
     [
       {
-        for k, v in coalesce(var.variables, {}) : v => trimprefix(v, "sm:") if startswith(v, "sm:")
+        for k, v in coalesce(var.variables, {}) : v => trimprefix(v, "asm://") if startswith(v, "asm://")
       },
       {
-        for k, v in coalesce(var.secrets, {}) : v => trimprefix(v, "sm:") if startswith(v, "sm:")
+        for k, v in coalesce(var.secrets, {}) : v => trimprefix(v, "asm://") if startswith(v, "asm://")
       },
     ],
     [
       for k, v in coalesce(var.environments, {}) : {
-        for name, variable in coalesce(v.variables, {}) : variable => trimprefix(variable, "sm:") if startswith(variable, "sm:")
+        for name, variable in coalesce(v.variables, {}) : variable => trimprefix(variable, "asm://") if startswith(variable, "asm://")
       }
     ],
     [
       for k, v in coalesce(var.environments, {}) : {
-        for name, secret in coalesce(v.secrets, {}) : secret => trimprefix(secret, "sm:") if startswith(secret, "sm:")
+        for name, secret in coalesce(v.secrets, {}) : secret => trimprefix(secret, "asm://") if startswith(secret, "asm://")
       }
     ]
   ])...)

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -87,12 +87,12 @@ func (s *ComponentSuite) TestBasic() {
 			},
 		},
 		"variables": map[string]interface{}{
-			"test_variable": fmt.Sprintf("ssm:%s", ssmSecretPath),
-			"test_variable_2": fmt.Sprintf("sm:%s", createdSecretName),
+			"test_variable": fmt.Sprintf("ssm://%s", ssmSecretPath),
+			"test_variable_2": fmt.Sprintf("asm://%s", createdSecretName),
 		},
 		"secrets": map[string]interface{}{
-			"test_secret": fmt.Sprintf("ssm:%s", ssmSecretPath),
-			"test_secret_2": fmt.Sprintf("sm:%s", createdSecretName),
+			"test_secret": fmt.Sprintf("ssm://%s", ssmSecretPath),
+			"test_secret_2": fmt.Sprintf("asm://%s", createdSecretName),
 		},
 		"environments": map[string]interface{}{
 			"development": map[string]interface{}{
@@ -124,12 +124,12 @@ func (s *ComponentSuite) TestBasic() {
 				"can_admins_bypass": false,
 				"prevent_self_review": false,
 				"variables": map[string]interface{}{
-					"test_variable": fmt.Sprintf("ssm:%s", ssmSecretPath),
-					"test_variable_2": fmt.Sprintf("sm:%s", smSecretPath),
+					"test_variable": fmt.Sprintf("ssm://%s", ssmSecretPath),
+					"test_variable_2": fmt.Sprintf("asm://%s", smSecretPath),
 				},
 				"secrets": map[string]interface{}{
-					"test_secret": fmt.Sprintf("ssm:%s", ssmSecretPath),
-					"test_secret_2": fmt.Sprintf("sm:%s", smSecretPath),
+					"test_secret": fmt.Sprintf("ssm://%s", ssmSecretPath),
+					"test_secret_2": fmt.Sprintf("asm://%s", smSecretPath),
 				},
 			},
 		},


### PR DESCRIPTION
## what
* Replace `ssm:` with `ssm://`
* Replace `sm:` with `asm://`

## why
* Have standard uri notation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized external reference format to URI style: asm:// for AWS Secrets Manager and ssm:/// for AWS Systems Manager Parameter Store. Replaces legacy sm: and ssm: formats across variables/secrets and environment configs.
- Documentation
  - Updated READMEs and examples to use asm:// and ssm:/// formats; existing guidance otherwise unchanged.
- Tests
  - Updated test data to the new URI-style secret and parameter references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->