### PR TITLE
Missing Deployment Branch Policy Inputs

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -88,9 +88,11 @@ locals {
 
   environments = {
     for k, v in coalesce(var.environments, {}) : k => {
-      wait_timer          = v.wait_timer
-      can_admins_bypass   = v.can_admins_bypass
-      prevent_self_review = v.prevent_self_review
+      wait_timer               = v.wait_timer
+      can_admins_bypass        = v.can_admins_bypass
+      prevent_self_review      = v.prevent_self_review
+      reviewers                = v.reviewers
+      deployment_branch_policy = v.deployment_branch_policy
       variables = {
         for name, variable in coalesce(v.variables, {}) : name => (
           startswith(variable, "ssm://") ? nonsensitive(data.aws_ssm_parameter.default[variable].value) :

--- a/test/fixtures/stacks/catalog/usecase/import.yaml
+++ b/test/fixtures/stacks/catalog/usecase/import.yaml
@@ -23,7 +23,7 @@ components:
           jira:
             key_prefix: "JIRA-"
             target_url_template: "https://jira.example.com/browse/<num>"
-        
+
         variables:
           test_variable_2: "test-value-2"
 
@@ -36,9 +36,6 @@ components:
             wait_timer: 1
             can_admins_bypass: true
             prevent_self_review: false
-            deployment_branch_policy:
-              protected_branches: true
-              custom_branches: null
             variables:
               test_variable: "test"
             # Secrets do not support import
@@ -67,4 +64,3 @@ components:
           bug:
             color: "#d73a4a"
             description: "Something isn't working"
-


### PR DESCRIPTION
## what
- Add reviewers and deployment branch policy to environments

## why
- Missing from the local var passed to the module

## references
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to define reviewers per environment, enabling approval workflows before deployments proceed.
  * Introduced per-environment deployment branch policies to restrict deployments to designated branches.
  * These options enhance governance and provide finer control over who can approve changes and where they can be deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->