### PR TITLE
feat!: remove rulesets etag output

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -53,11 +53,6 @@ output "collaborators_invitation_ids" {
   value       = module.repository.collaborators_invitation_ids
 }
 
-output "rulesets_etags" {
-  description = "Rulesets etags"
-  value       = module.repository.rulesets_etags
-}
-
 output "rulesets_node_ids" {
   description = "Rulesets node IDs"
   value       = module.repository.rulesets_node_ids


### PR DESCRIPTION
## what

Removing drifting rulesets etags from outputs.

## why

Rulesets etags cause drifting output. It was outlined in corresponding Terraform module, too. See references.

## references

https://github.com/cloudposse/terraform-github-repository/pull/19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed rulesets_etags from exported outputs. Other rulesets-related outputs including rulesets_node_ids and rulesets_rules_ids remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->