### PR TITLE
fix: add missing field for ruleset

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -303,6 +303,7 @@ variable "rulesets" {
       }), null),
       creation         = optional(bool, false),
       deletion         = optional(bool, false),
+      update           = optional(bool, false),
       non_fast_forward = optional(bool, false),
       required_pull_request_reviews = optional(object({
         dismiss_stale_reviews           = bool


### PR DESCRIPTION
## what

Adding missing `update` rulesets field.

## why

`update` field is available in the child module (`terraform-github-repository`), but not passed from root module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ruleset configuration now supports an optional `update` setting for rules, providing additional configuration flexibility. This new field defaults to false.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->