### PR TITLE
feat: upgrade terraform module

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "repository" {
   source  = "cloudposse/repository/github"
-  version = "1.1.0"
+  version = "1.5.0"
 
   enabled = local.enabled
 

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = ">= 6.6.0"
+      version = ">= 6.10.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Upgrade `cloudposse/repository/github` Terraform module from `1.1.0` to `1.5.0`
* Bump minimum required version of the `integrations/github` provider from `>= 6.6.0` to `>= 6.10.0`

## why
* Stay current with upstream module improvements and bug fixes introduced between `1.1.0` and `1.5.0`
* Align provider constraint with the minimum version required by the updated module

## references
* [`cloudposse/terraform-github-repository` releases](https://github.com/cloudposse/terraform-github-repository/releases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure module dependency to a newer version
  * Updated GitHub provider version requirement to ensure compatibility with latest features and fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->