### PR TITLE
feat: add organization repository roles flag

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -60,14 +60,15 @@ module "repository" {
   custom_properties = var.custom_properties
   environments      = local.environments
 
-  variables   = local.variables
-  secrets     = local.secrets
-  deploy_keys = var.deploy_keys
-  webhooks    = var.webhooks
-  labels      = var.labels
-  teams       = var.teams
-  users       = var.users
-  rulesets    = var.rulesets
+  variables                             = local.variables
+  secrets                               = local.secrets
+  deploy_keys                           = var.deploy_keys
+  webhooks                              = var.webhooks
+  labels                                = var.labels
+  teams                                 = var.teams
+  users                                 = var.users
+  organization_repository_roles_enabled = var.organization_repository_roles_enabled
+  rulesets                              = var.rulesets
 }
 
 locals {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -262,6 +262,12 @@ variable "users" {
   nullable    = false
 }
 
+variable "organization_repository_roles_enabled" {
+  description = "Whether to use organization repository roles."
+  type        = bool
+  default     = false
+}
+
 variable "rulesets" {
   description = "A map of rulesets to configure for the repository"
   type = map(object({


### PR DESCRIPTION
## what

Adding organization repository roles flag to the variables as a follow-up of this change: https://github.com/cloudposse/terraform-github-repository/pull/23.

## why

Organization repository roles support was added to the `terraform-github-repository` module recently. Component should handle it, too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable organization-level repository roles; disabled by default to preserve existing behavior.

* **Chores**
  * Internal alignment and formatting of module inputs for consistency — no changes to runtime behavior or exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->