### PR TITLE
fix: skip environment import when not in configuration

### DIFF
--- a/src/import.tf
+++ b/src/import.tf
@@ -1,7 +1,11 @@
 locals {
   import = local.enabled && var.import
 
-  environments_exists = local.import ? data.github_repository_environments.default[var.repository.name].environments[*].name : []
+  import_environments = local.import && length(local.environments) > 0
+  environments_exists = local.import_environments ? [
+    for environment in data.github_repository_environments.default[var.repository.name].environments[*].name :
+    environment if can(local.environments[environment])
+  ] : []
 }
 
 # Check if the repository exists
@@ -23,7 +27,7 @@ import {
 }
 
 data "github_repository_environments" "default" {
-  for_each   = toset(local.import ? [var.repository.name] : [])
+  for_each   = toset(local.import_environments ? [var.repository.name] : [])
   repository = each.value
 }
 


### PR DESCRIPTION
## what

Importing environments only when there's configuration associated with them.

## why

Import of environments should only happen when there's configuration that defines them. Otherwise, Terraform attempts to import environments that exist in GitHub, but are not specified in configuration.
