### PR TITLE
fix: drop iam roles from github repository provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,5 +31,5 @@
 - CI: ensure pre-commit, TFLint, and tests pass. Avoid unrelated changes in the same PR.
 
 ## Security & Configuration Tips
-- Never commit secrets. Configure AWS credentials/role assumption externally; the provider setup in `src/providers.tf` supports role assumption via the `iam_roles` module.
+- Never commit secrets. Configure AWS credentials/role assumption externally; `src/providers.tf` only configures the AWS region for optional SSM and Secrets Manager lookups.
 - Global quotas must be applied in `us-east-1`; place in the `gbl` stack and set `region: us-east-1` in `vars`.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,6 @@ The following configurations are not supported for import:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_repository"></a> [repository](#module\_repository) | cloudposse/repository/github | 1.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/src/README.md
+++ b/src/README.md
@@ -292,7 +292,6 @@ The following configurations are not supported for import:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_repository"></a> [repository](#module\_repository) | cloudposse/repository/github | 1.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,19 +1,3 @@
 provider "aws" {
   region = var.region
-
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
-  dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
-    content {
-      role_arn = assume_role.value
-    }
-  }
-}
-
-module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
-  context = module.this.context
 }


### PR DESCRIPTION
## What

Remove the `iam_roles` account-map subcomponent from the GitHub repository component provider configuration.

The AWS provider is still present because the component can read repository secret values from SSM Parameter Store and AWS Secrets Manager, but it now uses the ambient AWS credentials supplied by the runner/environment instead of resolving account-map roles.

## Why

This component manages GitHub repositories, not AWS IAM resources. Pulling in `../account-map/modules/iam-roles` adds dynamic AWS identity/account-map data to otherwise GitHub-focused plans. In workflows that save a plan under one identity and apply under another, that identity-dependent data can make the saved plan differ from the apply-time plan even when the visible GitHub resource changes are the same.

## Migration note

Existing workspaces that have already applied this component with `module.iam_roles` in state may need a one-time state cleanup after upgrading.

If OpenTofu/Terraform reports that it cannot read the schema for `cloudposse/awsutils` while decoding old state, remove the obsolete module state entry before planning/applying this version, for example:

```shell
terraform state rm 'module.iam_roles'
```

That state entry only represented the provider/account-map helper path used for role resolution. The component no longer declares or uses it after this change.

## Notes

- This intentionally does not add a bypass/migration shim because the component does not need account-map role resolution at runtime.
- AWS credential or role assumption should be configured outside this component, for example by the CI runner, Atmos auth wrapper, or the surrounding execution environment.

## Validation

- `terraform fmt -check src/providers.tf`
- `terraform -chdir=src init -backend=false`
- `terraform -chdir=src validate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider configuration guidance to reflect that AWS region is the only configurable setting for optional lookups.
  * Removed references to the `iam_roles` module from module documentation tables.

* **Chores**
  * Simplified AWS provider configuration to region setting only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->