### PR TITLE
feat: support ruleset pull request required reviewers

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "repository" {
   source  = "cloudposse/repository/github"
-  version = "1.6.0"
+  version = "1.8.0"
 
   enabled = local.enabled
 

--- a/src/providers.github.tf
+++ b/src/providers.github.tf
@@ -1,4 +1,3 @@
 provider "github" {
   owner = var.owner
 }
-

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -344,6 +344,11 @@ variable "rulesets" {
         require_last_push_approval        = optional(bool, false)
         required_approving_review_count   = optional(number, 0)
         required_review_thread_resolution = optional(bool, false)
+        required_reviewers = optional(list(object({
+          team              = string
+          file_patterns     = list(string)
+          minimum_approvals = number
+        })), [])
       }), null),
       required_deployments = optional(object({
         required_deployment_environments = optional(list(string), [])
@@ -405,6 +410,21 @@ variable "rulesets" {
   validation {
     condition     = alltrue([for k, v in var.rulesets : try(contains(["RepositoryRole", "Team", "Integration", "OrganizationAdmin"], v.bypass_actors.actor_type), true)])
     error_message = "Ruleset actor type must be RepositoryRole, Team, Integration or OrganizationAdmin"
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.rulesets : [
+        for required_reviewer in try(v.rules.pull_request.required_reviewers, []) :
+        required_reviewer.minimum_approvals >= 0 && required_reviewer.minimum_approvals <= 10
+      ]
+    ]))
+    error_message = "Ruleset pull request required reviewers minimum approvals must be between 0 and 10"
+  }
+
+  validation {
+    condition     = alltrue([for k, v in var.rulesets : try(length(v.rules.pull_request.required_reviewers) <= 15, true)])
+    error_message = "Ruleset pull request required reviewers can not have more than 15 teams"
   }
 
   validation {

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = ">= 6.6.0"
+      version = ">= 6.11.0"
     }
   }
 }


### PR DESCRIPTION
## what

Supporting required reviewers in pull request block within ruleset.

## why

Terraform provider since 6.11 allows to specify required reviewers within pull request block in ruleset.

## references

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#required-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring required pull-request reviewers by team, file patterns, and minimum approval count.
  - Supports up to 15 reviewer rules, with approval requirements from 0 to 10.

- **Documentation**
  - Updated configuration documentation to describe the new required-reviewer settings and their available options.

- **Improvements**
  - Added validation to help prevent invalid reviewer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->